### PR TITLE
Added message translation usecase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
             <version>5.8.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.deepl.api</groupId>
+            <artifactId>deepl-java</artifactId>
+            <version>1.7.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/config.properties
+++ b/src/config.properties
@@ -1,1 +1,2 @@
 mongodb.connectionString=mongodb+srv://INSERTUSERNAME:INSERTPASSWORD@linkup.szhpc.mongodb.net/?retryWrites=true&w=majority&appName=LinkUp
+deepl.apikey=INSERTAPIKEY

--- a/src/daos/MessageDAO.java
+++ b/src/daos/MessageDAO.java
@@ -65,8 +65,6 @@ public class MessageDAO implements MessageTranslationDataAccessInterface {
         Translator translator = new Translator(authkey);
         TextResult result = translator.translateText(message, null, targetLanguage);
 
-        saveTranslation(message, targetLanguage, result.getText());
-
         return result.getText();
     }
 }

--- a/src/daos/MessageDAO.java
+++ b/src/daos/MessageDAO.java
@@ -5,14 +5,11 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.deepl.api.*;
 import database.MongoDBConnection;
-import entity.Message;
 import entity.MessageFactory;
 import org.bson.Document;
 import usecases.message_translation.MessageTranslationDataAccessInterface;
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.util.Scanner;
+import java.io.FileInputStream;
+import java.util.Properties;
 
 public class MessageDAO implements MessageTranslationDataAccessInterface {
     private final MongoClient mongoClient;
@@ -56,7 +53,15 @@ public class MessageDAO implements MessageTranslationDataAccessInterface {
 
     @Override
     public String translateMessage(String message, String targetLanguage) throws DeepLException, InterruptedException {
-        String authkey = "DEEPLAPIKEY";
+        String authkey = null;
+
+        Properties properties = new Properties();
+        try (FileInputStream input = new FileInputStream("src/config.properties")) {
+            properties.load(input);
+            authkey = properties.getProperty("deepl.apikey");
+        } catch (Exception e) {
+            System.out.println("Error: " + e.getMessage());
+        }
         Translator translator = new Translator(authkey);
         TextResult result = translator.translateText(message, null, targetLanguage);
 

--- a/src/daos/MessageDAO.java
+++ b/src/daos/MessageDAO.java
@@ -1,4 +1,67 @@
 package daos;
 
-public class MessageDAO {
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.deepl.api.*;
+import database.MongoDBConnection;
+import entity.Message;
+import entity.MessageFactory;
+import org.bson.Document;
+import usecases.message_translation.MessageTranslationDataAccessInterface;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+public class MessageDAO implements MessageTranslationDataAccessInterface {
+    private final MongoClient mongoClient;
+    private final MongoDatabase database;
+    private final MongoCollection<Document> groupCollection;
+    private final MongoCollection<Document> userCollection;
+    private final MongoCollection<Document> translationsCollection;
+    private final MessageFactory messageFactory;
+
+    public MessageDAO(MessageFactory messageFactory) {
+        this.mongoClient = MongoDBConnection.getMongoClient();
+        this.database = mongoClient.getDatabase("LinkUp");
+        this.groupCollection = database.getCollection("groups");
+        this.userCollection = database.getCollection("users");
+        this.translationsCollection = database.getCollection("translations");
+        this.messageFactory = messageFactory;
+    }
+
+    @Override
+    public boolean messageAlreadyTranslated(String message, String targetLanguage) {
+        Document query = new Document("original_message", message)
+                .append("target_language", targetLanguage);
+        return translationsCollection.find(query).first() != null;
+    }
+
+    @Override
+    public String getTranslatedMessage(String message, String targetLanguage) {
+        Document query = new Document("original_message", message)
+                .append("target_language", targetLanguage);
+        Document result = translationsCollection.find(query).first();
+        return result.getString("translated_message");
+    }
+
+    @Override
+    public void saveTranslation(String message, String targetLanguage, String translatedMessage) {
+        Document translation = new Document("original_message", message)
+                .append("target_language", targetLanguage)
+                .append("translated_message", translatedMessage);
+        translationsCollection.insertOne(translation);
+    }
+
+    @Override
+    public String translateMessage(String message, String targetLanguage) throws DeepLException, InterruptedException {
+        String authkey = "DEEPLAPIKEY";
+        Translator translator = new Translator(authkey);
+        TextResult result = translator.translateText(message, null, targetLanguage);
+
+        saveTranslation(message, targetLanguage, result.getText());
+
+        return result.getText();
+    }
 }

--- a/src/daos/UserGroupDAO.java
+++ b/src/daos/UserGroupDAO.java
@@ -151,7 +151,8 @@ public class UserGroupDAO implements CreateGroupDataAccessInterface,addPersonalE
         for (Message message : messages) {
             Document messageDoc = new Document("message", message.getMessage())
                     .append("sender", message.getSender().getName())
-                    .append("time", message.getTime().toString());
+                    .append("time", message.getTime().toString())
+                    .append("language", message.getLanguage());
             messageDocs.add(messageDoc);
         }
         return messageDocs;
@@ -202,7 +203,9 @@ public class UserGroupDAO implements CreateGroupDataAccessInterface,addPersonalE
             String textmessage = messageDoc.getString("message");
             User sender = userFactory.create(messageDoc.getString("sender"), "defaultpassword", "defaultlanguage");
             LocalDateTime time = LocalDateTime.parse(messageDoc.getString("time"));
-            Message message = messageFactory.create(sender, textmessage);
+            String language = messageDoc.getString("language");
+
+            Message message = messageFactory.create(sender, textmessage, language);
             message.setTime(time);
             messages.add(message);
         }

--- a/src/entity/CommonMessage.java
+++ b/src/entity/CommonMessage.java
@@ -7,11 +7,13 @@ public class CommonMessage implements Message {
     private User sender;
     private String message;
     private LocalDateTime time;
+    private String language;
 
-    public CommonMessage(User sender, String message) {
+    public CommonMessage(User sender, String message, String language) {
         this.sender = sender;
         this.message = message;
         this.time = LocalDateTime.now();
+        this.language = language;
     }
 
     @Override
@@ -37,6 +39,16 @@ public class CommonMessage implements Message {
     @Override
     public LocalDateTime getTime() {
         return time;
+    }
+
+    @Override
+    public String getLanguage() {
+        return language;
+    }
+
+    @Override
+    public void setLanguage(String language) {
+        this.language = language;
     }
 
     public void setTime(LocalDateTime time) {this.time = time;}

--- a/src/entity/CommonMessageFactory.java
+++ b/src/entity/CommonMessageFactory.java
@@ -6,7 +6,7 @@ package entity;
 public class CommonMessageFactory implements MessageFactory {
 
     @Override
-    public Message create(User sender, String message)  {
-        return new CommonMessage(sender, message) ;
+    public Message create(User sender, String message, String language)  {
+        return new CommonMessage(sender, message, language) ;
     }
 }

--- a/src/entity/Message.java
+++ b/src/entity/Message.java
@@ -44,4 +44,8 @@ public interface Message {
     LocalDateTime getTime();
 
     void setTime(LocalDateTime time);
+
+    String getLanguage();
+
+    void setLanguage(String language);
 }

--- a/src/entity/MessageFactory.java
+++ b/src/entity/MessageFactory.java
@@ -8,9 +8,10 @@ public interface MessageFactory {
      * Creates a new Message.
      * @param name the name of the new message
      * @param  the password of the new message
+     * @param the language of the new message
      * @return the new user
      */
 
-    Message create(User sender, String message);
+    Message create(User sender, String message, String language);
 
 }

--- a/src/interface_adapter/MessageTranslation/MessageTranslationPresenter.java
+++ b/src/interface_adapter/MessageTranslation/MessageTranslationPresenter.java
@@ -1,0 +1,21 @@
+package interface_adapter.MessageTranslation;
+
+import entity.Message;
+import usecases.message_translation.MessageTranslationOutputBoundary;
+
+public class MessageTranslationPresenter implements MessageTranslationOutputBoundary {
+    public MessageTranslationPresenter() {
+        // TODO: Implement this constructor
+    }
+
+    @Override
+    public void presentTranslatedMessage(Message translatedMessage) {
+        // TODO: Implement this method
+    }
+
+    @Override
+    public void presentTranslationError(String errorMessage) {
+        // TODO: Implement this method
+    }
+
+}

--- a/src/usecases/message_translation/MessageTranslationDataAccessInterface.java
+++ b/src/usecases/message_translation/MessageTranslationDataAccessInterface.java
@@ -1,0 +1,7 @@
+package usecases.message_translation;
+
+public interface MessageTranslationDataAccessInterface {
+
+    boolean messageAlreadyTranslated(String message, String language);
+
+}

--- a/src/usecases/message_translation/MessageTranslationDataAccessInterface.java
+++ b/src/usecases/message_translation/MessageTranslationDataAccessInterface.java
@@ -1,7 +1,14 @@
 package usecases.message_translation;
 
+import com.deepl.api.DeepLException;
+
 public interface MessageTranslationDataAccessInterface {
 
     boolean messageAlreadyTranslated(String message, String language);
 
+    String getTranslatedMessage(String message, String targetLanguage);
+
+    void saveTranslation(String message, String targetLanguage, String translatedMessage);
+
+    String translateMessage(String message, String targetLanguage) throws DeepLException, InterruptedException;
 }

--- a/src/usecases/message_translation/MessageTranslationInputBoundary.java
+++ b/src/usecases/message_translation/MessageTranslationInputBoundary.java
@@ -1,0 +1,5 @@
+package usecases.message_translation;
+
+public interface MessageTranslationInputBoundary {
+    void execute(MessageTranslationInputData MessageTranslationInputData);
+}

--- a/src/usecases/message_translation/MessageTranslationInputBoundary.java
+++ b/src/usecases/message_translation/MessageTranslationInputBoundary.java
@@ -1,5 +1,7 @@
 package usecases.message_translation;
 
+import com.deepl.api.DeepLException;
+
 public interface MessageTranslationInputBoundary {
-    void execute(MessageTranslationInputData MessageTranslationInputData);
+    void execute(MessageTranslationInputData MessageTranslationInputData) throws DeepLException, InterruptedException;
 }

--- a/src/usecases/message_translation/MessageTranslationInputData.java
+++ b/src/usecases/message_translation/MessageTranslationInputData.java
@@ -19,4 +19,16 @@ public class MessageTranslationInputData {
         this.group = group;
         this.language = language;
     }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public User getUser() {
+        return sender;
+    }
 }

--- a/src/usecases/message_translation/MessageTranslationInputData.java
+++ b/src/usecases/message_translation/MessageTranslationInputData.java
@@ -1,0 +1,22 @@
+package usecases.message_translation;
+
+import entity.User;
+import entity.Group;
+
+import java.time.LocalDateTime;
+
+public class MessageTranslationInputData {
+    private User sender;
+    private String message;
+    private LocalDateTime time;
+    private Group group;
+    private String language;
+
+    public MessageTranslationInputData(User sender, String message, Group group, String language) {
+        this.sender = sender;
+        this.message = message;
+        this.time = LocalDateTime.now();
+        this.group = group;
+        this.language = language;
+    }
+}

--- a/src/usecases/message_translation/MessageTranslationInteractor.java
+++ b/src/usecases/message_translation/MessageTranslationInteractor.java
@@ -1,0 +1,4 @@
+package usecases.message_translation;
+
+public class MessageTranslationInteractor {
+}

--- a/src/usecases/message_translation/MessageTranslationInteractor.java
+++ b/src/usecases/message_translation/MessageTranslationInteractor.java
@@ -1,4 +1,59 @@
 package usecases.message_translation;
 
-public class MessageTranslationInteractor {
+import com.deepl.api.DeepLException;
+import daos.UserGroupDAO;
+import entity.Message;
+import entity.MessageFactory;
+
+public class MessageTranslationInteractor implements MessageTranslationInputBoundary {
+    final MessageTranslationDataAccessInterface messageTranslationDataAccess;
+    final MessageTranslationOutputBoundary messageTranslationPresenter;
+    final MessageFactory messageFactory;
+
+    public MessageTranslationInteractor(MessageTranslationDataAccessInterface messageTranslationDataAccess,
+                                        MessageTranslationOutputBoundary messageTranslationPresenter,
+                                        MessageFactory messageFactory) {
+        this.messageTranslationDataAccess = messageTranslationDataAccess;
+        this.messageTranslationPresenter = messageTranslationPresenter;
+        this.messageFactory = messageFactory;
+    }
+
+    @Override
+    public void execute(MessageTranslationInputData inputData) throws DeepLException, InterruptedException {
+        // if message is already translated, return the message from the db
+        // else, translate the message and store it in the db
+        // if language is invalid, set fail view
+        if (!isValidLanguage(inputData.getLanguage())) {
+            messageTranslationPresenter.presentTranslationError("Invalid language");
+        }
+        else if(messageAlreadyTranslated(inputData.getMessage(), inputData.getLanguage())) {
+            String storedMessage = messageTranslationDataAccess.getTranslatedMessage(inputData.getMessage(), inputData.getLanguage());
+            Message translatedMessage = messageFactory.create(inputData.getUser(), storedMessage, inputData.getLanguage());
+            messageTranslationPresenter.presentTranslatedMessage(translatedMessage);
+        }
+        else {
+            String translatedMessageString = messageTranslationDataAccess.translateMessage(inputData.getMessage(), inputData.getLanguage());
+            Message translatedMessage = messageFactory.create(inputData.getUser(), translatedMessageString, inputData.getLanguage());
+            messageTranslationDataAccess.saveTranslation(inputData.getMessage(), inputData.getLanguage(), translatedMessageString);
+            messageTranslationPresenter.presentTranslatedMessage(translatedMessage);
+        }
+    }
+
+    private boolean isValidLanguage(String language) {
+        return language.equals("EN-US") || // English (American)
+                language.equals("AR") || // Arabic
+                language.equals("FR") || // French
+                language.equals("ES") || // Spanish
+                language.equals("IT") || // Italian
+                language.equals("JA") || // Japanese
+                language.equals("KO") || // Korean
+                language.equals("RU") || // Russian
+                language.equals("ZH-HANS") || // Chinese (Simplified)
+                language.equals("EL") || // Greek
+                language.equals("PT-BR"); // Portuguese (Brazil)
+    }
+
+    private boolean messageAlreadyTranslated(String message, String language) {
+        return messageTranslationDataAccess.messageAlreadyTranslated(message, language);
+    }
 }

--- a/src/usecases/message_translation/MessageTranslationOutputBoundary.java
+++ b/src/usecases/message_translation/MessageTranslationOutputBoundary.java
@@ -1,6 +1,8 @@
 package usecases.message_translation;
 
+import entity.Message;
+
 public interface MessageTranslationOutputBoundary {
-    void presentTranslatedMessage(String translatedMessage);
+    void presentTranslatedMessage(Message translatedMessage);
     void presentTranslationError(String errorMessage);
 }

--- a/src/usecases/message_translation/MessageTranslationOutputBoundary.java
+++ b/src/usecases/message_translation/MessageTranslationOutputBoundary.java
@@ -1,0 +1,6 @@
+package usecases.message_translation;
+
+public interface MessageTranslationOutputBoundary {
+    void presentTranslatedMessage(String translatedMessage);
+    void presentTranslationError(String errorMessage);
+}

--- a/src/usecases/message_translation/MessageTranslationOutputData.java
+++ b/src/usecases/message_translation/MessageTranslationOutputData.java
@@ -1,0 +1,42 @@
+package usecases.message_translation;
+
+import entity.Group;
+import entity.User;
+
+import java.time.LocalDateTime;
+
+public class MessageTranslationOutputData {
+    private User sender;
+    private String message;
+    private LocalDateTime time;
+    private Group group;
+    private String language;
+
+    public MessageTranslationOutputData(User sender, String message, LocalDateTime time, Group group, String language) {
+        this.sender = sender;
+        this.message = message;
+        this.time = time;
+        this.group = group;
+        this.language = language;
+    }
+
+    public User getSender() {
+        return sender;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDateTime getTime() {
+        return time;
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+}


### PR DESCRIPTION
### Message Translation Usecase
<!-- Provide a concise and descriptive title for your pull request. -->

---

### Description
<!-- Describe what changes are being made and why. Explain the problem this PR solves or the feature it adds. -->
This pull request introduces functionality for translating messages into various languages using the DeepL API. It includes mechanisms for storing and retrieving translations to minimize redundant API calls and integrates language metadata into message objects for better tracking.
<img width="458" alt="image" src="https://github.com/user-attachments/assets/9786712a-4734-4dec-9ccc-8cbb269bedfa">


---

### Changes
- Added MessageTranslationDataAccessInterface and its implementation in MessageDAO for handling translation-related data operations.
- Updated CommonMessage, Message, and MessageFactory classes to include a language field.
- Enhanced UserGroupDAO to serialize and deserialize the language field for messages.
- Introduced the MessageTranslationInteractor to handle translation use cases.
- Created input and output boundary interfaces (MessageTranslationInputBoundary and MessageTranslationOutputBoundary) and their respective data classes (MessageTranslationInputData and MessageTranslationOutputData).
- Added MessageTranslationPresenter as a presenter for translation results.
- Included DeepL API dependency in pom.xml.

---

### Checklist
- [X] Code is clean and follows the project's coding standards
- [X] Documentation has been updated (if necessary)
- [X] All tests pass locally (if applicable)

---

### Additional Comments
<!-- Add any additional notes or context that reviewers should be aware of -->
Currently, the DeepL Translation API supports 500,000 characters per month. As such, the API key will be included closer towards the project submission.