### PR TITLE
Added addGroupEvent Usecase

### DIFF
--- a/src/app/AppBuilder.java
+++ b/src/app/AppBuilder.java
@@ -5,6 +5,9 @@ import entity.*;
 import interface_adapter.AddFriend.AddFriendController;
 import interface_adapter.AddFriend.AddFriendPresenter;
 import interface_adapter.AddFriend.AddFriendViewModel;
+import interface_adapter.AddGroupEvent.AddGroupEventController;
+import interface_adapter.AddGroupEvent.AddGroupEventPresenter;
+import interface_adapter.AddGroupEvent.AddGroupEventViewModel;
 import interface_adapter.AddGroupMember.AddGroupMemberController;
 import interface_adapter.AddGroupMember.AddGroupMemberPresenter;
 import interface_adapter.AddGroupMember.AddGroupMemberViewModel;
@@ -43,6 +46,9 @@ import interface_adapter.GroupChat.GroupChatViewModel;
 import usecases.add_friend.AddFriendInputBoundary;
 import usecases.add_friend.AddFriendInteractor;
 import usecases.add_friend.AddFriendOutputBoundary;
+import usecases.add_group_event.AddGroupEventInputBoundary;
+import usecases.add_group_event.AddGroupEventInteractor;
+import usecases.add_group_event.AddGroupEventOutputBoundary;
 import usecases.add_group_member.AddGroupMemberInputBoundary;
 import usecases.add_group_member.AddGroupMemberInteractor;
 import usecases.add_group_member.AddGroupMemberOutputBoundary;
@@ -183,6 +189,12 @@ public class AppBuilder {
     private final AddRecommendedEventInputBoundary addRecommendedEventInteractor = new AddRecommendedEventInteractor(mongoDAO, addRecommendedEventOutputBoundary);
     private final AddRecommendedEventController addRecommendedEventController = new AddRecommendedEventController(addRecommendedEventInteractor);
 
+    // addGroupEventUseCase
+    private final AddGroupEventViewModel addGroupEventViewModel = new AddGroupEventViewModel();
+    private final AddGroupEventOutputBoundary addGroupEventOutputBoundary = new AddGroupEventPresenter(addGroupEventViewModel);
+    private final AddGroupEventInputBoundary addGroupEventInteractor = new AddGroupEventInteractor(mongoDAO, addGroupEventOutputBoundary, eventFactory);
+    private final AddGroupEventController addGroupEventController = new AddGroupEventController(addGroupEventInteractor);
+
     // Instance variables for views
     private final AccountCreationView accountCreationView = new AccountCreationView(accountCreationViewModel, viewManager);
     private final LoginView loginView = new LoginView(loginViewModel, viewManager);
@@ -190,7 +202,8 @@ public class AppBuilder {
     private final UserSettingsView userSettingsView = new UserSettingsView(viewManager, addPersonalEventViewModel, addFriendViewModel,
             changeLanguageViewModel, deletePersonalEventViewModel, removeFriendViewModel);
     private final CreateGroupView createGroupView = new CreateGroupView(createGroupViewModel, viewManager);
-    private final GroupSettingsView groupSettingsView = new GroupSettingsView(viewManager, timeslotSelectionViewModel, addGroupMemberViewModel, removeGroupMemberViewModel, addRecommendedEventViewModel);
+    private final GroupSettingsView groupSettingsView = new GroupSettingsView(viewManager, timeslotSelectionViewModel, addGroupMemberViewModel,
+            removeGroupMemberViewModel, addRecommendedEventViewModel, addGroupEventViewModel);
     public AppBuilder() {
         cardPanel.setLayout(cardLayout);
 
@@ -268,6 +281,11 @@ public class AppBuilder {
 
     public AppBuilder addAddRecommendedEventUseCase() {
         groupSettingsView.setAddRecommendedEventController(addRecommendedEventController);
+        return this;
+    }
+
+    public AppBuilder addGroupEventUseCase() {
+        groupSettingsView.setAddGroupEventController(addGroupEventController);
         return this;
     }
 

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -19,6 +19,7 @@ public class Main {
                 .addTimeslotSelectionUseCase()
                 .addRemoveFriendUseCase()
                 .addAddRecommendedEventUseCase()
+                .addGroupEventUseCase()
                 .build();
 
         application.pack();

--- a/src/interface_adapter/AddGroupEvent/AddGroupEventController.java
+++ b/src/interface_adapter/AddGroupEvent/AddGroupEventController.java
@@ -1,0 +1,20 @@
+package interface_adapter.AddGroupEvent;
+
+import interface_adapter.AddGroupMember.AddGroupMemberController;
+import usecases.add_group_event.AddGroupEventInputBoundary;
+import usecases.add_group_event.AddGroupEventInputData;
+import usecases.add_group_event.AddGroupEventInteractor;
+import usecases.add_group_event.AddGroupEventOutputBoundary;
+
+public class AddGroupEventController {
+    private final AddGroupEventInputBoundary addGroupEventInteractor;
+
+    public AddGroupEventController(AddGroupEventInputBoundary addGroupEventInteractor) {
+        this.addGroupEventInteractor = addGroupEventInteractor;
+    }
+
+    public void execute(String groupname, String eventname, String startTime, String endTime) {
+        addGroupEventInteractor.executeCreate(new AddGroupEventInputData(groupname, eventname, startTime, endTime));
+    }
+
+}

--- a/src/interface_adapter/AddGroupEvent/AddGroupEventPresenter.java
+++ b/src/interface_adapter/AddGroupEvent/AddGroupEventPresenter.java
@@ -1,0 +1,29 @@
+package interface_adapter.AddGroupEvent;
+
+
+import usecases.add_group_event.AddGroupEventOutputBoundary;
+import usecases.add_group_event.AddGroupOutputData;
+
+public class AddGroupEventPresenter implements AddGroupEventOutputBoundary {
+    private AddGroupEventViewModel viewModel;
+
+    public AddGroupEventPresenter(AddGroupEventViewModel viewModel) {
+        this.viewModel = viewModel;
+    }
+
+
+    @Override
+    public void setPassView(AddGroupOutputData outputData) {
+        AddGroupEventState addGroupEventState = viewModel.getState();
+        addGroupEventState.setGroupname(outputData.getGroupName());
+        addGroupEventState.setEventname(outputData.getEventName());
+        viewModel.firePropertyChanged("addGroupEventSuccess");
+    }
+
+    @Override
+    public void setFailView(String error) {
+        AddGroupEventState addGroupEventState = viewModel.getState();
+        addGroupEventState.setError(error);
+        viewModel.firePropertyChanged("addGroupEventError");
+    }
+}

--- a/src/interface_adapter/AddGroupEvent/AddGroupEventState.java
+++ b/src/interface_adapter/AddGroupEvent/AddGroupEventState.java
@@ -1,0 +1,31 @@
+package interface_adapter.AddGroupEvent;
+
+public class AddGroupEventState {
+    private String groupname;
+    private String eventname;
+    private String error;
+
+    public void setGroupname(String groupname) {
+        this.groupname = groupname;
+    }
+
+    public void setEventname(String eventname) {
+        this.eventname = eventname;
+    }
+
+    public String getGroupname() {
+        return groupname;
+    }
+
+    public String getEventname() {
+        return eventname;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public String getError() {
+        return error;
+    }
+}

--- a/src/interface_adapter/AddGroupEvent/AddGroupEventViewModel.java
+++ b/src/interface_adapter/AddGroupEvent/AddGroupEventViewModel.java
@@ -1,0 +1,10 @@
+package interface_adapter.AddGroupEvent;
+
+import interface_adapter.ViewModel;
+
+public class AddGroupEventViewModel extends ViewModel<AddGroupEventState> {
+    public AddGroupEventViewModel() {
+        super("addGroupEvent");
+        setState(new AddGroupEventState());
+    }
+}

--- a/src/usecases/add_group_event/AddGroupEventDataAccessInterface.java
+++ b/src/usecases/add_group_event/AddGroupEventDataAccessInterface.java
@@ -1,0 +1,7 @@
+package usecases.add_group_event;
+
+import entity.Event;
+
+public interface AddGroupEventDataAccessInterface {
+    void addGroupEvent(String groupname, Event event);
+}

--- a/src/usecases/add_group_event/AddGroupEventInputBoundary.java
+++ b/src/usecases/add_group_event/AddGroupEventInputBoundary.java
@@ -1,0 +1,5 @@
+package usecases.add_group_event;
+
+public interface AddGroupEventInputBoundary {
+    void executeCreate(AddGroupEventInputData inputData);
+}

--- a/src/usecases/add_group_event/AddGroupEventInputData.java
+++ b/src/usecases/add_group_event/AddGroupEventInputData.java
@@ -1,0 +1,31 @@
+package usecases.add_group_event;
+
+public class AddGroupEventInputData {
+    private String groupName;
+    private String eventName;
+    private String startTime;
+    private String endTime;
+
+    public AddGroupEventInputData(String groupName, String eventName, String startTime, String endTime) {
+        this.groupName = groupName;
+        this.eventName = eventName;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public String getEventName() {
+        return eventName;
+    }
+
+    public String getStartTime() {
+        return startTime;
+    }
+
+    public String getEndTime() {
+        return endTime;
+    }
+}

--- a/src/usecases/add_group_event/AddGroupEventInteractor.java
+++ b/src/usecases/add_group_event/AddGroupEventInteractor.java
@@ -1,0 +1,61 @@
+package usecases.add_group_event;
+
+import entity.Event;
+import entity.EventFactory;
+import usecases.add_personal_event.AddPersonalEventInputData;
+import usecases.add_personal_event.AddPersonalEventInteractor;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public class AddGroupEventInteractor implements AddGroupEventInputBoundary {
+    private final AddGroupEventDataAccessInterface dataAccess;
+    private final AddGroupEventOutputBoundary outputBoundary;
+    private EventFactory eventFactory;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    public AddGroupEventInteractor(AddGroupEventDataAccessInterface dataAccess, AddGroupEventOutputBoundary outputBoundary, EventFactory eventFactory) {
+        this.dataAccess = dataAccess;
+        this.outputBoundary = outputBoundary;
+        this.eventFactory = eventFactory;
+    }
+
+    @Override
+    public void executeCreate(AddGroupEventInputData inputData) {
+        if (missingFields(inputData)) {
+            outputBoundary.setFailView("Fill in all Fields!");
+        } else if (!validTime(inputData.getStartTime(), inputData.getEndTime())) {
+            outputBoundary.setFailView("Invalid Time Format!");
+        } else {
+            Event event = eventFactory.create(inputData.getEventName(), parseDateTime(inputData.getStartTime())
+                    ,parseDateTime(inputData.getEndTime()), true);
+            dataAccess.addGroupEvent(inputData.getGroupName(), event);
+            outputBoundary.setPassView(new AddGroupOutputData(inputData.getGroupName(), event.getEventName()));
+        }
+    }
+
+    private boolean missingFields(AddGroupEventInputData inputData) {
+        return inputData.getEventName().isEmpty() || inputData.getStartTime().isEmpty() || inputData.getEndTime().isEmpty();
+    }
+
+    private boolean validTime(String startTime, String endTime) {
+        LocalDateTime startDateTime = parseDateTime(startTime);
+        LocalDateTime endDateTime = parseDateTime(endTime);
+
+        if (startDateTime == null || endDateTime == null) {
+            return false;
+        }
+
+        return startDateTime.isBefore(endDateTime);
+    }
+
+    private LocalDateTime parseDateTime(String dateTimeStr) {
+        try {
+            dateTimeStr = dateTimeStr.trim().toUpperCase();
+            return LocalDateTime.parse(dateTimeStr, FORMATTER);
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+}

--- a/src/usecases/add_group_event/AddGroupEventOutputBoundary.java
+++ b/src/usecases/add_group_event/AddGroupEventOutputBoundary.java
@@ -1,0 +1,9 @@
+package usecases.add_group_event;
+
+
+public interface AddGroupEventOutputBoundary {
+
+    void setPassView(AddGroupOutputData outputData);
+
+    void setFailView(String error);
+}

--- a/src/usecases/add_group_event/AddGroupOutputData.java
+++ b/src/usecases/add_group_event/AddGroupOutputData.java
@@ -1,0 +1,19 @@
+package usecases.add_group_event;
+
+public class AddGroupOutputData {
+    private String eventName;
+    private String groupName;
+
+    public AddGroupOutputData(String groupName, String eventName) {
+        this.groupName = groupName;
+        this.eventName = eventName;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public String getEventName() {
+        return eventName;
+    }
+}

--- a/src/views/GroupSettingsView.java
+++ b/src/views/GroupSettingsView.java
@@ -10,6 +10,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import interface_adapter.AddGroupEvent.AddGroupEventController;
+import interface_adapter.AddGroupEvent.AddGroupEventState;
+import interface_adapter.AddGroupEvent.AddGroupEventViewModel;
 import interface_adapter.AddRecommendedEvent.AddRecommendedEventController;
 import interface_adapter.AddRecommendedEvent.AddRecommendedEventState;
 import interface_adapter.AddRecommendedEvent.AddRecommendedEventViewModel;
@@ -48,10 +51,15 @@ public class GroupSettingsView extends JPanel implements ActionListener, Propert
 
     private final AddRecommendedEventViewModel addRecommendedEventViewModel;
     private AddRecommendedEventController addRecommendedEventController;
+
+    private final AddGroupEventViewModel addGroupEventViewModel;
+    private AddGroupEventController addGroupEventController;
+
     private String currentGroup; // Instance variable to store the current group name
 
     public GroupSettingsView(ViewManager viewManager, TimeslotSelectionViewModel timeslotSelectionViewModel, AddGroupMemberViewModel addGroupMemberViewModel, 
-                             RemoveGroupMemberViewModel removeGroupMemberViewModel, AddRecommendedEventViewModel addRecommendedEventViewModel) {
+                             RemoveGroupMemberViewModel removeGroupMemberViewModel, AddRecommendedEventViewModel addRecommendedEventViewModel,
+                             AddGroupEventViewModel addGroupEventViewModel) {
         this.addGroupMemberViewModel = addGroupMemberViewModel;
         addGroupMemberViewModel.addPropertyChangeListener(this);
 
@@ -64,6 +72,9 @@ public class GroupSettingsView extends JPanel implements ActionListener, Propert
 
         this.addRecommendedEventViewModel = addRecommendedEventViewModel;
         addRecommendedEventViewModel.addPropertyChangeListener(this);
+
+        this.addGroupEventViewModel = addGroupEventViewModel;
+        addGroupEventViewModel.addPropertyChangeListener(this);
 
         this.setLayout(new BorderLayout());
         this.setPreferredSize(new Dimension(1280, 720));
@@ -304,8 +315,7 @@ public class GroupSettingsView extends JPanel implements ActionListener, Propert
         String command = e.getActionCommand();
 
         if ("ADD EVENT".equals(command)) {
-            JOptionPane.showMessageDialog(this, "NOT IMPLEMENTED", "Warning", JOptionPane.WARNING_MESSAGE);
-            // TODO: Implement Add Event logic
+            addGroupEventController.execute(currentGroup, eventNameField.getText(), eventStartField.getText(), eventEndField.getText());
         } else if ("Add Recommended Event".equals(command)) {
             addRecommendedEventController.excute(reccomendedEvent, currentGroup);
         }
@@ -346,6 +356,16 @@ public class GroupSettingsView extends JPanel implements ActionListener, Propert
             refreshEvents();
             refreshGroupMembers();
             refreshNewMembers();
+        } else if ("addGroupEventSuccess".equals(evt.getPropertyName())) {
+            AddGroupEventState addGroupEventState = (AddGroupEventState) evt.getNewValue();
+            String eventName = addGroupEventState.getEventname();
+            JOptionPane.showMessageDialog(this, "The event " + eventName + " was successfully added to " + currentGroup + "!", "Success", JOptionPane.INFORMATION_MESSAGE);
+            refreshReccomendation();
+            refreshEvents();
+        } else if ("addGroupEventError".equals(evt.getPropertyName())) {
+            AddGroupEventState addGroupEventState = (AddGroupEventState) evt.getNewValue();
+            String error = addGroupEventState.getError();
+            JOptionPane.showMessageDialog(this, error, "Error", JOptionPane.ERROR_MESSAGE);
         }
     }
 
@@ -367,5 +387,9 @@ public class GroupSettingsView extends JPanel implements ActionListener, Propert
 
     public void setRemoveGroupMemberController(RemoveGroupMemberController removeGroupMemberController) {
         this.removeGroupMemberController = removeGroupMemberController;
+    }
+
+    public void setAddGroupEventController(AddGroupEventController addGroupEventController) {
+        this.addGroupEventController = addGroupEventController;
     }
 }


### PR DESCRIPTION
### Pull Request Title
Added `addGroupEvent` Use Case

---

### Description
Implemented the `addGroupEvent` use case to allow adding group events to a group’s calendar. This feature enables users to manage events within their group settings effectively.
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/51638f53-35a4-40e3-8b76-49353b0b490c">

---

### Changes
- Added `addGroupEvent` logic in `MongoDAO`.
- Created new interfaces and classes:
  - `AddGroupEventInputBoundary`
  - `AddGroupEventOutputBoundary`
  - `AddGroupEventInteractor`
  - `AddGroupEventInputData`
  - `AddGroupOutputData`
  - `AddGroupEventController`
  - `AddGroupEventPresenter`
  - `AddGroupEventViewModel`
  - `AddGroupEventState`
- Integrated the `addGroupEvent` feature into:
  - `AppBuilder`
  - `GroupSettingsView`
  - `Main`
- Updated the `GroupSettingsView` to handle success and error states for group event creation.

---

### Checklist
- [x] Code is clean and follows the project's coding standards.
- [x] Documentation has been updated where necessary.
- [x] All tests pass locally.

---

### Additional Comments
This feature introduces a new way for group members to add events directly through the UI. Event validation and formatting ensure proper functionality and data integrity.