### PR TITLE
Modified add personal event to add to groups

### DIFF
--- a/src/test/java/usecases/add_personal_event/AddPersonalEventInteractorTest.java
+++ b/src/test/java/usecases/add_personal_event/AddPersonalEventInteractorTest.java
@@ -29,6 +29,11 @@ class AddPersonalEventInteractorTest {
         public void addEvent(User user, Event event) {
             // Simulate adding the event (No real DB)
         }
+
+        @Override
+        public void addGroupEvent(String groupname, Event event) {
+            // Simulate adding the event to a group (No real DB)
+        }
     }
 
     class MockAddPersonalEventOutput implements AddPersonalEventOutputBoundary {

--- a/src/usecases/add_personal_event/AddPersonalEventDataAccessInterface.java
+++ b/src/usecases/add_personal_event/AddPersonalEventDataAccessInterface.java
@@ -5,4 +5,6 @@ import entity.User;
 public interface AddPersonalEventDataAccessInterface {
 
     public void addEvent(User user, Event event);
+
+    void addGroupEvent(String groupname, Event event);
 }

--- a/src/usecases/add_personal_event/AddPersonalEventInteractor.java
+++ b/src/usecases/add_personal_event/AddPersonalEventInteractor.java
@@ -1,6 +1,9 @@
 package usecases.add_personal_event;
 import entity.Event;
 import entity.EventFactory;
+import entity.Group;
+import entity.User;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -28,6 +31,10 @@ public class AddPersonalEventInteractor implements AddPersonalEventInputBoundary
             Event event = eventFactory.create(inputData.getEventName(), parseDateTime(inputData.getStartTime())
                     ,parseDateTime(inputData.getEndTime()), false);
             dataAccess.addEvent(inputData.getUser(), event);
+            for (Group group : inputData.getUser().getGroups()) {
+                dataAccess.addGroupEvent(group.getName(), event);
+                group.addGroupEvent(event);
+            }
             AddPersonalEventOutputData outputData = new AddPersonalEventOutputData(event.getEventName(), event.getStartTime().toString(), event.getEndTime().toString());
             inputData.getUser().getUserCalendar().addEvent(event);
             outputBoundary.setPassView(outputData);


### PR DESCRIPTION
### Pull Request Title
Modified add personal event to add to groups

---

### Description
This pull request extends the functionality of the "Add Personal Event" use case to also add events to all the groups a user is part of. When a personal event is created, it is now shared across the user's associated groups.

---

### Changes
- **New Functionality**: 
  - Added a method `addGroupEvent` to the `AddPersonalEventDataAccessInterface` to allow events to be added to groups.
  - Updated the `AddPersonalEventInteractor` to iterate through the user's groups and add the created event to each group.
- **Modified Files**:
  - **`AddPersonalEventInteractor.java`**: Implemented logic to add events to groups.
  - **`AddPersonalEventDataAccessInterface.java`**: Added a new method signature for adding group events.
  - **`AddPersonalEventInteractorTest.java`**: Updated the test mock to simulate adding group events.

---

### Checklist
- [x] Code is clean and follows the project's coding standards.
- [x] Documentation has been updated to reflect changes (if necessary).
- [x] All tests pass locally with the new changes.
- [x] Changes do not introduce breaking functionality.

---

### Additional Comments
This enhancement ensures group collaboration is improved by automatically sharing personal events across groups. No breaking changes or new dependencies were introduced. This PR paves the way for tighter group integration. 

---

Feel free to review and merge once approved!